### PR TITLE
Fix JSON response of user delete

### DIFF
--- a/src/controllers/DeleteAccountController.php
+++ b/src/controllers/DeleteAccountController.php
@@ -18,15 +18,15 @@ class DeleteAccountController extends Controller
          $this->requirePostRequest();
 
          $request = Craft::$app->getRequest();
-         $deleteResponse = Porter::getInstance()->deleteAccount->deleteAccount($request);
+         $action = Porter::getInstance()->deleteAccount->deleteAccount($request);
 
-         if ($deleteResponse)
+         if ($action)
          {
-            if ($deleteResponse['message']) {
-               $this->asJson($deleteResponse);
+            if ($action['message']) {
+               return $this->asJson($action);
+            } else {
+               return $this->redirectToPostedUrl();
             }
-            
-            return $this->redirectToPostedUrl();
          }
 
    }

--- a/src/controllers/DeleteAccountController.php
+++ b/src/controllers/DeleteAccountController.php
@@ -18,9 +18,14 @@ class DeleteAccountController extends Controller
          $this->requirePostRequest();
 
          $request = Craft::$app->getRequest();
+         $deleteResponse = Porter::getInstance()->deleteAccount->deleteAccount($request);
 
-         if (Porter::getInstance()->deleteAccount->deleteAccount($request))
+         if ($deleteResponse)
          {
+            if ($deleteResponse['message']) {
+               $this->asJson($deleteResponse);
+            }
+            
             return $this->redirectToPostedUrl();
          }
 

--- a/src/services/DeleteAccount.php
+++ b/src/services/DeleteAccount.php
@@ -108,10 +108,11 @@ class DeleteAccount extends Component
 
                if ($request->getAcceptsJson()) 
                {
-                  return $this->asJson([
+
+                  return [
                      'success' => false,
                      'message' => Craft::t('porter', 'porter_delete_account_flash_admins')
-                  ]);
+                  ];
                }
 
                Craft::$app->getSession()->setFlash('porter', Craft::t('porter', 'porter_delete_account_flash_admins'));
@@ -150,10 +151,10 @@ class DeleteAccount extends Component
 
                   if ($request->getAcceptsJson()) 
                   {
-                     return $this->asJson([
+                     return [
                         'success' => true,
                         'message' => Craft::t('porter', 'porter_delete_account_flash_success')
-                     ]);
+                     ];
                   }
 
                   Craft::$app->getSession()->setFlash('porter', Craft::t('porter', 'porter_delete_account_flash_success'));
@@ -166,10 +167,10 @@ class DeleteAccount extends Component
 
             if ($request->getAcceptsJson()) 
             {
-               return $this->asJson([
+               return [
                   'success' => false,
                   'message' => Craft::t('porter', 'porter_delete_account_flash_incorrect')
-               ]);
+               ];
             }
 
             Craft::$app->getSession()->setFlash('porter', Craft::t('porter', 'porter_delete_account_flash_incorrect'));
@@ -181,10 +182,10 @@ class DeleteAccount extends Component
 
          if ($request->getAcceptsJson()) 
          {
-            return $this->asJson([
+            return [
                'success' => false,
                'message' => Craft::t('porter', 'porter_delete_account_flash_permission')
-            ]);
+            ];
          }
          
          Craft::$app->getSession()->setFlash('porter', Craft::t('porter', 'porter_delete_account_flash_permission'));


### PR DESCRIPTION
Hi, 
we're using Porter to enable our users to delete their own profile on the frontend, and it's working wonders!
We noticed, that after turning our form to AJAX we got an error into the encoding of the message response when we moved to application/json content-type.
I think that this pull request will fix all the cases in when asJson was called from the service (it's only a Controller method)

Thanks!