### PR TITLE
Fixed: Password policy check excluded exact min/max length passwords

### DIFF
--- a/src/services/EmailPassword.php
+++ b/src/services/EmailPassword.php
@@ -41,14 +41,14 @@ class EmailPassword extends Component
          }
       }
 
-      if (strlen($password) <= $this->settings->passwordForcePolicyMin)
+      if (strlen($password) < $this->settings->passwordForcePolicyMin)
       {
          $errors[] = Craft::t('porter', 'Password must contain at least {min} characters.', ['min' => $this->settings->passwordForcePolicyMin]);
       }
 
-      if (strlen($password) <= $this->settings->passwordForcePolicyMin && strlen($password) >= $this->settings->passwordForcePolicyMax)
+      if (strlen($password) > $this->settings->passwordForcePolicyMax)
       {
-         $errors[] = Craft::t('porter', 'Password must be less than {max} characters.', ['max' => $this->settings->passwordForcePolicyMax]);
+         $errors[] = Craft::t('porter', 'Password must be no longer than {max} characters.', ['max' => $this->settings->passwordForcePolicyMax]);
       }
 
       return $errors;


### PR DESCRIPTION
In the settings menu for Porter, we set a Password Minimum Length and a Password Maximum Length. Say we set those to 8 and 128 respectively, then passwords with a length of either 8 or 128 characters should be considered valid.

Currently, the enforcement of the policy in the checkPasswordPolicy() method invalidates those exact-length passwords.

This pull request fixes that.